### PR TITLE
Faithfully link symlinks even when they're broken

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ function linkRecursivelySync (src, dest, _mkdirp) {
   if (_mkdirp == null) _mkdirp = true
   // Note: We could try readdir'ing and catching ENOTDIR exceptions, but that
   // is 3x slower than stat'ing in the common case that we have a file.
-  var srcStats = fs.statSync(src)
+  var srcStats = fs.lstatSync(src)
   if (srcStats.isDirectory()) {
     mkdirp.sync(dest)
     var entries = fs.readdirSync(src)


### PR DESCRIPTION
This little change prevents `linkRecursivelySync` from crashing if it encounters a broken symlink. This is relevant to me because Emacs creates broken symlinks as part of its file locking scheme, which can crash `ember server`. 

The resulting behavior is consistent with the way `linkRecursivelySync` is already intended to work: it just faithfully `link(2)`s every symlink it encounters, whether it's broken or not.
