### PR TITLE
Retarget the symlink to use the absolute path.

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,11 @@ function copyPreserveSync (src, dest, srcStats) {
     fs.writeFileSync(dest, content, { flag: 'wx' })
     fs.utimesSync(dest, srcStats.atime, srcStats.mtime)
   } else if (srcStats.isSymbolicLink()) {
-    fs.symlinkSync(fs.readlinkSync(src), dest)
+    // Identify the absolute path for the symlink target.
+    var from = path.dirname(src)
+    var to = fs.readlinkSync(src)
+    fs.symlinkSync(path.resolve(from, to), dest)
+
     // We cannot update the atime/mtime of a symlink yet:
     // https://github.com/joyent/node/issues/2142
   } else {


### PR DESCRIPTION
This is one alternative to close #3.