### PR TITLE
Use MD5 for hashStrings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master
 
+* Speed up `hashStrings` by using `MD5` (instead of `SHA256`).
+
 # 0.2.2
 
 * Make `hashTree` match after `copyRecursivelySync`, by disregarding the

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ function hashStats (stats, path) {
 exports.hashStrings = hashStrings
 function hashStrings (strings) {
   var joinedStrings = strings.join('\x00')
-  return crypto.createHash('sha256').update(joinedStrings).digest('hex')
+  return crypto.createHash('md5').update(joinedStrings).digest('hex')
 }
 
 


### PR DESCRIPTION
I wrote a quick profiling script [here](https://gist.github.com/rjackson/e690eaebcb9171826b5d) that generates a hash of 1000 random strings repeatedly, and MD5 is approximately twice as fast as SHA256.
