### PR TITLE
validate multiGlob’s input.

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,7 +194,11 @@ function assertAbsolutePaths (paths) {
 
 // Multi-glob with reasonable defaults, so APIs all behave the same
 exports.multiGlob = multiGlob
+
 function multiGlob (globs, globOptions) {
+  if (!Array.isArray(globs)) {
+    throw new TypeError("multiGlob's first argument must be an array");
+  }
   var options = {
     nomount: true,
     strict: true


### PR DESCRIPTION
This provides a useful error message if a non-array is passed to multiGlob
