### PR TITLE
Fixes broccoli#183

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ function multiGlob (globs, globOptions) {
     }
     var matches = glob.sync(globs[i], options)
     if (matches.length === 0) {
-      throw new Error('Path or pattern "' + globs[i] + '" did not match any files')
+      console.warn('Path or pattern "' + options.cwd + globs[i] + '" did not match any files')
     }
     for (var j = 0; j < matches.length; j++) {
       if (!pathSet[matches[j]]) {


### PR DESCRIPTION
This PR changes the behaviour of `helpers.multiGlob` so that zero-length matches result in a console warning rather than an error that fails the build - it goes with https://github.com/broccolijs/broccoli/issues/183.
