### PR TITLE
enable hashTree to be inlined

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,16 +8,16 @@ var isWindows = process.platform === 'win32'
 var pathSep   = path.sep
 
 exports.hashTree = hashTree
+// This function is used by the watcher. It makes the following guarantees:
+//
+// (1) It never throws an exception.
+//
+// (2) It does not miss changes. In other words, if after this function returns,
+// any part of the directory hierarchy changes, a subsequent call must
+// return a different hash.
+//
+// (1) and (2) hold even in the face of a constantly-changing file system.
 function hashTree (fullPath) {
-  // This function is used by the watcher. It makes the following guarantees:
-  //
-  // (1) It never throws an exception.
-  //
-  // (2) It does not miss changes. In other words, if after this function returns,
-  // any part of the directory hierarchy changes, a subsequent call must
-  // return a different hash.
-  //
-  // (1) and (2) hold even in the face of a constantly-changing file system.
   return hashStrings(keysForTree(fullPath))
 }
 


### PR DESCRIPTION
v8 decides if it can inline a function based on its AST size, it also decides the inline depth limit by total AST Size. As it turns out, V8 also includes comments in this count...
