### PR TITLE
Instead of hashing trees by mtime and size, hash by file content.

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,10 @@ function keysForTree (fullPath, initialRelativePath, options) {
 
 exports.digestOfFileContents = digestOfFileContents;
 function digestOfFileContents (fullPath, relativePath, stats, options) {
+  if (relativePath === '.') {
+    throw new Error('digestOfFileContents got relativePath of ".", needs broccoli-filter customizations to pass along correct relative path to hashTree');
+  }
+
   var digest,
       optionalDigestCache = options !== undefined ? options.digestCache : undefined,
       fileDigestCacheKey = [


### PR DESCRIPTION
This allows for the cache to be hit far more often, especially when you are modifying the content of a file back and forth (e.g. frequent undo/redo).

Also, added an optional `digestCache` option to `hashTree(...)` which is used to prevent unnecessary file reads (if the mtime and size of the file haven’t changed, assume that we don’t need to re-read & hash its contents).
