### PR TITLE
`matches.length === 0` should warn

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,7 +199,7 @@ function multiGlob (globs, globOptions) {
     }
     var matches = glob.sync(globs[i], options)
     if (matches.length === 0) {
-      throw new Error('Path or pattern "' + globs[i] + '" did not match any files')
+      console.warn('Warning: Path or pattern "' + globs[i] + '" did not match any files')
     }
     for (var j = 0; j < matches.length; j++) {
       if (!pathSet[matches[j]]) {


### PR DESCRIPTION
I'm unable to use `!` negating in a path because `glob` isn't finding any results which is causing this error to be thrown.
No matches is (mostly) harmless and is a potentially expected, perfectly reasonable result.
