### PR TITLE
Update glob dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,6 +182,7 @@ function multiGlob (globs, globOptions) {
     throw new TypeError("multiGlob's first argument must be an array");
   }
   var options = {
+    follow: true,
     nomount: true,
     strict: true
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   },
   "dependencies": {
     "mkdirp": "^0.3.5",
-    "glob": "4.0.4"
+    "glob": "^5.0.10"
   }
 }


### PR DESCRIPTION
Newer version of glob supports `follow: true`.
It should close #27 and it's needed for https://github.com/ember-cli/ember-cli/issues/4137.