### PR TITLE
Use newer mkdirp

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/broccolijs/broccoli-kitchen-sink-helpers"
   },
   "dependencies": {
-    "mkdirp": "^0.3.5",
+    "mkdirp": "^0.5.1",
     "glob": "^5.0.10"
   }
 }


### PR DESCRIPTION
The previously used version of `mkdirp` causes problems in strict mode or with `babel` converting it due to use of octal literals. substack/node-mkdirp#88

This should help broccoli-kitchen-sink work in more places for more people